### PR TITLE
Techborn patch 1

### DIFF
--- a/lib/js2xml.js
+++ b/lib/js2xml.js
@@ -1,5 +1,4 @@
 var common = require('./common');
-var count = 0;
 
 function validateOptions(userOptions) {
     var options = common.copyOptions(userOptions);

--- a/lib/js2xml.js
+++ b/lib/js2xml.js
@@ -192,7 +192,7 @@ function hasContentCompact(element, options, anyContent) {
 
 function writeElementCompact(element, name, options, depth, indent) {
     var xml = '';
-    if (element == undefined || element == null) {
+    if (typeof element === 'undefined' || element === null) {
         if (options.fullTagEmptyElement) {
             return '<' + name + '></' + name + '>';
         } else {
@@ -201,7 +201,7 @@ function writeElementCompact(element, name, options, depth, indent) {
     }
     if (name) {
         xml += '<' + name;
-        if (typeof element != 'object') {
+        if (typeof element !== 'object') {
             xml += '>' + writeText(element,options) + '</' + name + '>';
             return xml;
         }

--- a/lib/js2xml.js
+++ b/lib/js2xml.js
@@ -1,4 +1,5 @@
 var common = require('./common');
+var count = 0;
 
 function validateOptions(userOptions) {
     var options = common.copyOptions(userOptions);
@@ -192,23 +193,36 @@ function hasContentCompact(element, options, anyContent) {
 
 function writeElementCompact(element, name, options, depth, indent) {
     var xml = '';
-    if (name) {
-        xml += '<' + name;
-        if (element[options.attributesKey]) {
-            xml += writeAttributes(element[options.attributesKey], options);
-        }
-        if (options.fullTagEmptyElement || hasContentCompact(element, options, true) || element[options.attributesKey] && element[options.attributesKey]['xml:space'] === 'preserve') {
-            xml += '>';
+    if (element == undefined || element == null) {
+        if (options.fullTagEmptyElement) {
+            return '<' + name + '></' + name + '>';
         } else {
-            xml += '/>';
-            return xml;
+            return '';
         }
+    } else {
+        if (name) {
+            xml += '<' + name;
+            if (typeof element != 'object') {
+                xml += '>' + writeText(element,options) + '</' + name + '>';
+                return xml;
+            } else {
+                if (element[options.attributesKey]) {
+                    xml += writeAttributes(element[options.attributesKey], options);
+                }
+                if (options.fullTagEmptyElement || hasContentCompact(element, options, true) || element[options.attributesKey] && element[options.attributesKey]['xml:space'] === 'preserve') {
+                    xml += '>';
+                } else {
+                    xml += '/>';
+                    return xml;
+                }
+            }
+        }
+        xml += writeElementsCompact(element, options, depth + 1, false);
+        if (name) {
+            xml += (indent ? writeIndentation(options, depth, false) : '') + '</' + name + '>';
+        }
+        return xml;
     }
-    xml += writeElementsCompact(element, options, depth + 1, false);
-    if (name) {
-        xml += (indent ? writeIndentation(options, depth, false) : '') + '</' + name + '>';
-    }
-    return xml;
 }
 
 function writeElementsCompact(element, options, depth, firstLine) {

--- a/lib/js2xml.js
+++ b/lib/js2xml.js
@@ -1,4 +1,5 @@
 var common = require('./common');
+var count = 0;
 
 function validateOptions(userOptions) {
     var options = common.copyOptions(userOptions);
@@ -198,30 +199,28 @@ function writeElementCompact(element, name, options, depth, indent) {
         } else {
             return '';
         }
-    } else {
-        if (name) {
-            xml += '<' + name;
-            if (typeof element != 'object') {
-                xml += '>' + writeText(element,options) + '</' + name + '>';
-                return xml;
-            } else {
-                if (element[options.attributesKey]) {
-                    xml += writeAttributes(element[options.attributesKey], options);
-                }
-                if (options.fullTagEmptyElement || hasContentCompact(element, options, true) || element[options.attributesKey] && element[options.attributesKey]['xml:space'] === 'preserve') {
-                    xml += '>';
-                } else {
-                    xml += '/>';
-                    return xml;
-                }
-            }
-        }
-        xml += writeElementsCompact(element, options, depth + 1, false);
-        if (name) {
-            xml += (indent ? writeIndentation(options, depth, false) : '') + '</' + name + '>';
-        }
-        return xml;
     }
+    if (name) {
+        xml += '<' + name;
+        if (typeof element != 'object') {
+            xml += '>' + writeText(element,options) + '</' + name + '>';
+            return xml;
+        }
+        if (element[options.attributesKey]) {
+            xml += writeAttributes(element[options.attributesKey], options);
+        }
+        if (options.fullTagEmptyElement || hasContentCompact(element, options, true) || element[options.attributesKey] && element[options.attributesKey]['xml:space'] === 'preserve') {
+            xml += '>';
+        } else {
+            xml += '/>';
+            return xml;
+        }
+    }
+    xml += writeElementsCompact(element, options, depth + 1, false);
+    if (name) {
+        xml += (indent ? writeIndentation(options, depth, false) : '') + '</' + name + '>';
+    }
+    return xml;
 }
 
 function writeElementsCompact(element, options, depth, firstLine) {


### PR DESCRIPTION
Changes to allow for elements in compact mode to be expressed as a primitive value without requiring the textKey attribute when no other attributes are present. Undefined and null elements are skipped unless the fullEmptyTag option is passed. This change only affects the js->xml conversion

So, this (in yaml):
```yaml
example:
  __text: 'value'
```
is allowed to be expressed like this:
```yaml
example: 'value'
```