### PR TITLE
Fix #34: XML declarations using single quotes

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -96,13 +96,10 @@ function addField(type, value, options) {
 function onInstruction(instruction) {
     var attributes = {};
     if (instruction.body && (instruction.name.toLowerCase() === 'xml' || options.instructionHasAttributes)) {
-        while (instruction.body) {
-            var attribute = instruction.body.match(/([\w:-]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|(\w+))\s*/);
-            if (!attribute) {
-                break;
-            }
-            attributes[attribute[1]] = attribute[2];
-            instruction.body = instruction.body.slice(attribute[0].length); // advance the string
+        var attrsRegExp = /([\w:-]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|(\w+))\s*/g;
+        var match;
+        while ((match = attrsRegExp.exec(instruction.body)) !== null) {
+            attributes[match[1]] = match[2] || match[3] || match[4];
         }
     }
     if (instruction.name.toLowerCase() === 'xml') {

--- a/test/xml2js_test.js
+++ b/test/xml2js_test.js
@@ -660,6 +660,23 @@ describe('Testing xml2js.js:', function () {
 
         });
 
+        describe('case by Nuno Martins', function () {
+            // see https://github.com/nashwaan/xml-js/issues/34
+            var xml = '<?xml version=\'1.0\' encoding=\'UTF-8\'?>';
+            var js = {
+                declaration: {
+                    attributes: {
+                        version: '1.0',
+                        encoding: 'UTF-8'
+                    }
+                }
+            };
+
+            it('should accept XML declarations that use single quotes', function () {
+                expect(convert.xml2js(xml)).toEqual(js);
+            });
+        })
+
     });
 
 });


### PR DESCRIPTION
- Add simpler parsing of instructions: using RegExp's `exec`.
- Access all capturing patterns of the RegExp (effectively solving the issue).
- Add test case.