### PR TITLE
 Add nativeTypeAttributes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ The below options are applicable for both `xml2js()` and `xml2json()` functions.
 | `trim`              | `false` | Whether to trim whitespace characters that may exist before and after the text. |
 | `sanitize` ([Deprecated](https://github.com/nashwaan/xml-js/issues/26)) | `false` | Whether to replace `&` `<` `>` with `&amp;` `&lt;` `&gt;` respectively, in the resultant text. |
 | `nativeType`        | `false` | Whether to attempt converting text of numerals or of boolean values to native type. For example, `"123"` will be `123` and `"true"` will be `true` |
+| `nativeTypeAttributes` | `false` | Whether to attempt converting attributes of numerals or of boolean values to native type. See also `nativeType` above. |
 | `addParent`         | `false` | Whether to add `parent` property in each element object that points to parent object. |
 | `alwaysArray`       | `false` | Whether to always put sub element, even if it is one only, as an item inside an array. `<a><b/></a>` will be `a:[{b:[{}]}]` rather than `a:{b:{}}` (applicable for compact output only). |
 | `alwaysChildren`    | `false` | Whether to always generate `elements` property even when there are no actual sub elements. `<a></a>` will be `{"elements":[{"type":"element","name":"a","elements":[]}]}` rather than `{"elements":[{"type":"element","name":"a"}]}` (applicable for non-compact output). |

--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -22,6 +22,7 @@ function validateOptions(userOptions) {
   helper.ensureFlagExists('addParent', options);
   helper.ensureFlagExists('trim', options);
   helper.ensureFlagExists('nativeType', options);
+  helper.ensureFlagExists('nativeTypeAttributes', options);
   helper.ensureFlagExists('sanitize', options);
   helper.ensureFlagExists('instructionHasAttributes', options);
   helper.ensureFlagExists('captureSpacesBetweenElements', options);
@@ -134,11 +135,14 @@ function manipulateAttributes(attributes) {
   if ('attributesFn' in options && attributes) {
     attributes = options.attributesFn(attributes, currentElement);
   }
-  if ((options.trim || 'attributeValueFn' in options || 'attributeNameFn' in options) && attributes) {
+  if ((options.trim || 'attributeValueFn' in options || 'attributeNameFn' in options || options.nativeTypeAttributes) && attributes) {
     var key;
     for (key in attributes) {
       if (attributes.hasOwnProperty(key)) {
         if (options.trim) attributes[key] = attributes[key].trim();
+        if (options.nativeTypeAttributes) {
+          attributes[key] = nativeType(attributes[key]);
+        }
         if ('attributeValueFn' in options) attributes[key] = options.attributeValueFn(attributes[key], key, currentElement);
         if ('attributeNameFn' in options) {
           var temp = attributes[key];

--- a/test/test-items.js
+++ b/test/test-items.js
@@ -202,6 +202,12 @@ module.exports = function (direction, options) {
     return key;
   }
   function applyAttributesCallback(obj, key, parentKey) {
+    if (options.nativeTypeAttributes) {
+      var parsedNumber = Number(obj[key]);
+      if (!Number.isNaN(parsedNumber)) {
+        obj[key] = parsedNumber;
+      }
+    }
     if (('attributeNameFn' in options || 'attributeValueFn' in options) && (parentKey === '_attributes' || parentKey === 'attributes')) {
       if ('attributeNameFn' in options) {
         var temp = obj[key];

--- a/test/xml2js-options.spec.js
+++ b/test/xml2js-options.spec.js
@@ -75,6 +75,17 @@ describe('Testing xml2js.js:', function () {
 
     });
 
+    describe('options = {nativeTypeAttributes: true}', function () {
+
+      var options = {compact: false, nativeTypeAttributes: true};
+      testItems('xml2js', options).forEach(function (test) {
+        it(test.desc, function () {
+          expect(convert.xml2js(test.xml, options)).toEqual(test.js);
+        });
+      });
+
+    });
+
     describe('options = {alwaysChildren: true}', function () {
 
       var options = {compact: false, alwaysChildren: true};
@@ -401,6 +412,22 @@ describe('Testing xml2js.js:', function () {
       /*it('Parse improper XML', function () {
         expect(convert.xml2js('<a>x', {})).toEqual({"elements":[{"type":"element","name":"a","elements":[{"type":"text","text":"x"}]}]});
       });*/
+
+    });
+
+    describe('options = {nativeTypeAttributes: true}', function () {
+
+      var options = {nativeTypeAttributes: true};
+
+      it('Parse number', function () {
+        expect(convert.xml2js('<a data-value="123"></a>', options)).toEqual({"elements":[{"type":"element","name":"a","attributes":{"data-value":123}}]});
+      });
+      it('Parse true', function () {
+        expect(convert.xml2js('<a data-value="true"></a>', options)).toEqual({"elements":[{"type":"element","name":"a","attributes":{"data-value":true}}]});
+      });
+      it('Parse false', function () {
+        expect(convert.xml2js('<a data-value="false"></a>', options)).toEqual({"elements":[{"type":"element","name":"a","attributes":{"data-value":false}}]});
+      });
 
     });
 


### PR DESCRIPTION
Introduce a new `nativeTypeAttributes` option that automatically converts numbers and booleans in attribute values (similar to the existing `nativeType` option for text content).