### PR TITLE
Don't generate attributes with values `null` or `undefined`

### DIFF
--- a/lib/js2xml.js
+++ b/lib/js2xml.js
@@ -60,7 +60,7 @@ function writeAttributes(attributes, options, depth) {
   }
   var key, attr, attrName, quote, result = [];
   for (key in attributes) {
-    if (attributes.hasOwnProperty(key)) {
+    if (attributes.hasOwnProperty(key) && attributes[key] !== null && attributes[key] !== undefined) {
       quote = options.noQuotesForNativeAttributes && typeof attributes[key] !== 'string' ? '' : '"';
       attr = '' + attributes[key]; // ensure number and boolean are converted to String
       attr = attr.replace(/"/g, '&quot;');


### PR DESCRIPTION
Fixes #50 