### PR TITLE
`parentElement` is an object

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,21 +53,21 @@ declare namespace Options {
     alwaysChildren?: boolean
     instructionHasAttributes?: boolean
     captureSpacesBetweenElements?: boolean
-    doctypeFn?: (value: string, parentElement: string) => void;
+    doctypeFn?: (value: string, parentElement: object) => void;
     instructionFn?: (
       instructionValue: string,
       instructionName: string,
       parentElement: string
     ) => void;
-    cdataFn?: (value: string, parentElement: string) => void;
-    commentFn?: (value: string, parentElement: string) => void;
-    textFn?: (value: string, parentElement: string) => void;
+    cdataFn?: (value: string, parentElement: object) => void;
+    commentFn?: (value: string, parentElement: object) => void;
+    textFn?: (value: string, parentElement: object) => void;
     instructionNameFn?: (
       instructionName: string,
       instructionValue: string,
       parentElement: string
     ) => void;
-    elementNameFn?: (value: string, parentElement: string) => void;
+    elementNameFn?: (value: string, parentElement: object) => void;
     attributeNameFn?: (
       attributeName: string,
       attributeValue: string,


### PR DESCRIPTION
Since `parentElement` is just a part of `currentElement` which is an object ([see](https://github.com/nashwaan/xml-js/blob/d27442a5abefc9beb4e71d9fd3051717333f3893/lib/xml2js.js#L320)) it should be typed as an object.

