### PR TITLE
Add new options: lowercase and strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ The below options are applicable for both `xml2js()` and `xml2json()` functions.
 |:--------------------|:--------|:------------|
 | `compact`           | `false` | Whether to produce detailed object or compact object. |
 | `trim`              | `false` | Whether to trim whitespace characters that may exist before and after the text. |
+| `lowercase`         | `false` | Whether to force lowercase tag name. If true, then lowercase tag names and attribute names in loose mode, rather than uppercasing them. |
+| `strict`            | `true`  | Whether to use strict parsing mode. Defaults to `true` which is highly recommended, since parsing HTML which is not well-formed XML might yield just about anything |
 | `sanitize` ([Deprecated](https://github.com/nashwaan/xml-js/issues/26)) | `false` | Whether to replace `&` `<` `>` with `&amp;` `&lt;` `&gt;` respectively, in the resultant text. |
 | `nativeType`        | `false` | Whether to attempt converting text of numerals or of boolean values to native type. For example, `"123"` will be `123` and `"true"` will be `true` |
 | `nativeTypeAttributes` | `false` | Whether to attempt converting attributes of numerals or of boolean values to native type. See also `nativeType` above. |

--- a/lib/options-helper.js
+++ b/lib/options-helper.js
@@ -12,9 +12,9 @@ module.exports = {
     return copy;
   },
 
-  ensureFlagExists: function (item, options) {
+  ensureFlagExists: function (item, options, defaultValue = false) {
     if (!(item in options) || typeof options[item] !== 'boolean') {
-      options[item] = false;
+      options[item] = defaultValue;
     }
   },
 

--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -25,6 +25,8 @@ function validateOptions(userOptions) {
   helper.ensureFlagExists('sanitize', options);
   helper.ensureFlagExists('instructionHasAttributes', options);
   helper.ensureFlagExists('captureSpacesBetweenElements', options);
+  helper.ensureFlagExists('lowercase', options);
+  helper.ensureFlagExists('strict', options, true);
   helper.ensureAlwaysArrayExists(options);
   helper.ensureKeyExists('declaration', options);
   helper.ensureKeyExists('instruction', options);
@@ -314,12 +316,11 @@ function onError(error) {
 }
 
 module.exports = function (xml, userOptions) {
+  options = validateOptions(userOptions);
 
-  var parser = pureJsParser ? sax.parser(true, {}) : parser = new expat.Parser('UTF-8');
+  var parser = pureJsParser ? sax.parser(options.strict, {lowercase: options.lowercase}) : parser = new expat.Parser('UTF-8');
   var result = {};
   currentElement = result;
-
-  options = validateOptions(userOptions);
 
   if (pureJsParser) {
     parser.opt = {strictEntities: true};

--- a/test/xml2js-options.spec.js
+++ b/test/xml2js-options.spec.js
@@ -174,6 +174,17 @@ describe('Testing xml2js.js:', function () {
 
     });
 
+    describe('options = {lowercase: true, strict: false}', function () {
+
+      var options = {compact: false, lowercase: true, strict: false};
+      testItems('xml2js', options).forEach(function (test) {
+        it(test.desc, function () {
+          expect(convert.xml2js(test.xml, options)).toEqual(test.js);
+        });
+      });
+
+    });
+
   });
 
   describe('options = {compact: true}', function () {
@@ -313,6 +324,17 @@ describe('Testing xml2js.js:', function () {
     describe('options = {ignoreInstruction: true}', function () {
 
       var options = {compact: true, ignoreInstruction: true};
+      testItems('xml2js', options).forEach(function (test) {
+        it(test.desc, function () {
+          expect(convert.xml2js(test.xml, options)).toEqual(test.js);
+        });
+      });
+
+    });
+
+    describe('options = {lowercase: true, strict: false}', function () {
+
+      var options = {compact: true, lowercase: true, strict: false};
       testItems('xml2js', options).forEach(function (test) {
         it(test.desc, function () {
           expect(convert.xml2js(test.xml, options)).toEqual(test.js);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,6 +53,8 @@ declare namespace Options {
     alwaysChildren?: boolean
     instructionHasAttributes?: boolean
     captureSpacesBetweenElements?: boolean
+    lowercase?: boolean
+    strict?: boolean
     doctypeFn?: (value: string, parentElement: object) => void;
     instructionFn?: (
       instructionValue: string,


### PR DESCRIPTION
two options to pass to sax for parse non-strict xml like html

for example:
```xml
<meta http-equiv="Cache-Control" content="no-siteapp">
```