### PR TITLE
Inferring file type for non-lowercase filenames

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -66,10 +66,14 @@ if (options.version) {
   process.exit(process.argv.length <= 2 ? 1 : 0);
 } else if ('src' in options) {
   if (fs.statSync(options.src).isFile()) {
-    if (options.src.split('.').pop() === 'xml') {
+    if (options.src.split('.').pop().toLowerCase() === 'xml') {
       output = xml2json(fs.readFileSync(options.src, 'utf8'), options);
-    } else if (options.src.split('.').pop() === 'json') {
+    } else if (options.src.split('.').pop().toLowerCase() === 'json') {
       output = json2xml(fs.readFileSync(options.src, 'utf8'), options);
+    }
+    else {
+      console.error('File type not identified');
+      process.exit(1);
     }
     if (options.out) {
       fs.writeFileSync(options.out, output, 'utf8');


### PR DESCRIPTION
Hi,
When using the CLI on a filename whose extension is not fully lowercase (e.g. ```npx xml-js TEST.XML```) the CLI fails to recognize the file type and exits without any output or error code.  
I've added also an error print and error code for (legitimately) unrecognized file extensions.

Thanks for this project.