### PR TITLE
fixed xml2js's typing

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -151,4 +151,8 @@ declare namespace Options {
 export function js2xml(obj: Element | ElementCompact, options?: Options.JS2XML): string;
 export function json2xml(json: string, options?: Options.JS2XML): string;
 export function xml2json(xml: string, options?: Options.XML2JSON): string;
+
+export function xml2js(xml: string, options?: Options.XML2JS&{compact?:false}): Element;
+export function xml2js(xml: string): Element;
+export function xml2js(xml: string, options?: Options.XML2JS&{compact:true}): ElementCompact;
 export function xml2js(xml: string, options?: Options.XML2JS): Element | ElementCompact;


### PR DESCRIPTION
When calling xml2js with `options.compact === true`, returns `ElementCompact`
when `options.compact === false` or not specified, returns `Element`
when unknown returns `Element|ElementCompact`
