### PR TITLE
Write special XML characters in attributes as character entities.

### DIFF
--- a/lib/js2xml.js
+++ b/lib/js2xml.js
@@ -63,9 +63,8 @@ function writeAttributes(attributes, options, depth) {
     if (attributes.hasOwnProperty(key) && attributes[key] !== null && attributes[key] !== undefined) {
       quote = options.noQuotesForNativeAttributes && typeof attributes[key] !== 'string' ? '' : '"';
       attr = '' + attributes[key]; // ensure number and boolean are converted to String
-      attr = attr.replace(/['"<>&]/g, function replacer(match) {
+      attr = attr.replace(/["<>&]/g, function replacer(match) {
         switch (match) {
-          case "'":  return '&apos;';
           case '"':  return '&quot;';
           case '<':  return '&lt;';
           case '>':  return '&gt;';

--- a/lib/js2xml.js
+++ b/lib/js2xml.js
@@ -65,11 +65,11 @@ function writeAttributes(attributes, options, depth) {
       attr = '' + attributes[key]; // ensure number and boolean are converted to String
       attr = attr.replace(/['"<>&]/g, function replacer(match) {
         switch (match) {
-          case "'":  return '&apos;'; break;
-          case '"':  return '&quot;'; break;
-          case '<':  return '&lt;'; break;
-          case '>':  return '&gt;'; break;
-          case '&':  return '&amp;'; break;
+          case "'":  return '&apos;';
+          case '"':  return '&quot;';
+          case '<':  return '&lt;';
+          case '>':  return '&gt;';
+          case '&':  return '&amp;';
         }
       });
       attrName = 'attributeNameFn' in options ? options.attributeNameFn(key, attr, currentElementName, currentElement) : key;

--- a/lib/js2xml.js
+++ b/lib/js2xml.js
@@ -63,7 +63,15 @@ function writeAttributes(attributes, options, depth) {
     if (attributes.hasOwnProperty(key) && attributes[key] !== null && attributes[key] !== undefined) {
       quote = options.noQuotesForNativeAttributes && typeof attributes[key] !== 'string' ? '' : '"';
       attr = '' + attributes[key]; // ensure number and boolean are converted to String
-      attr = attr.replace(/"/g, '&quot;');
+      attr = attr.replace(/['"<>&]/g, function replacer(match) {
+        switch (match) {
+          case "'":  return '&apos;'; break;
+          case '"':  return '&quot;'; break;
+          case '<':  return '&lt;'; break;
+          case '>':  return '&gt;'; break;
+          case '&':  return '&amp;'; break;
+        }
+      });
       attrName = 'attributeNameFn' in options ? options.attributeNameFn(key, attr, currentElementName, currentElement) : key;
       result.push((options.spaces && options.indentAttributes? writeIndentation(options, depth+1, false) : ' '));
       result.push(attrName + '=' + quote + ('attributeValueFn' in options ? options.attributeValueFn(attr, key, currentElementName, currentElement) : attr) + quote);

--- a/test/test-items.js
+++ b/test/test-items.js
@@ -78,7 +78,7 @@ var cases = [
     js2: {"elements":[{"type":"element","name":"a","attributes":{"x":"hello"}}]}
   }, {
     desc: 'should convert attribute with special chars as character entities',
-    xml: '<a x="'&amp;&gt;&lt;&quot;"/>',
+    xml: '<a x="\'&amp;&gt;&lt;&quot;"/>',
     js1: {"a":{_attributes:{"x":"'&><\""}}},
     js2: {"elements":[{"type":"element","name":"a","attributes":{"x":"'&><\""}}]}
   }, {

--- a/test/test-items.js
+++ b/test/test-items.js
@@ -77,6 +77,11 @@ var cases = [
     js1: {"a":{_attributes:{"x":"hello"}}},
     js2: {"elements":[{"type":"element","name":"a","attributes":{"x":"hello"}}]}
   }, {
+    desc: 'should convert attribute with special chars as character entities',
+    xml: '<a x="'&amp;&gt;&lt;&quot;"/>',
+    js1: {"a":{_attributes:{"x":"'&><\""}}},
+    js2: {"elements":[{"type":"element","name":"a","attributes":{"x":"'&><\""}}]}
+  }, {
     desc: 'should convert 2 attributes',
     xml: '<a x="1.234" y="It\'s"/>',
     js1: {"a":{_attributes:{"x":"1.234","y":"It\'s"}}},


### PR DESCRIPTION
Cf. [XML 1.0 Standard, section 2.4](https://www.w3.org/TR/xml/#syntax) - strictly speaking, only `<`, `&`, the attribute value delimiter in use (either `'` or `"`), and `>` when preceded by `]]` are forbidden according to the standard.  For clarity of result, all chars but `'` are replaced (the latter for not breaking existing tests; exception causes no harm as attribute delimiters when writing xml are always `"`).