### PR TITLE
Added a missing property for options to index.d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -48,6 +48,7 @@ declare namespace Options {
     trim?: boolean
     sanitize?: boolean
     nativeType?: boolean
+    nativeTypeAttributes?: boolean
     addParent?: boolean
     alwaysArray?: boolean | Array<string>
     alwaysChildren?: boolean


### PR DESCRIPTION
Hi maintainer,
With this PR, I would like to suggest a fix for index.d.ts which has a missing option property (nativeTypeAttributes).
Thanks in advance,
-Shige