### PR TITLE
add a new option for `simpleAttributes` 

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -9,6 +9,7 @@ var currentElement;
 
 function validateOptions(userOptions) {
   options = helper.copyOptions(userOptions);
+  helper.ensureFlagExists('simpleAttributes', options);
   helper.ensureFlagExists('ignoreDeclaration', options);
   helper.ensureFlagExists('ignoreInstruction', options);
   helper.ensureFlagExists('ignoreAttributes', options);
@@ -210,11 +211,17 @@ function onStartElement(name, attributes) {
   if (options.compact) {
     element = {};
     if (!options.ignoreAttributes && attributes && Object.keys(attributes).length) {
-      element[options.attributesKey] = {};
+      if (!options.simpleAttributes) {
+        element[options.attributesKey] = {};
+      }
       var key;
       for (key in attributes) {
         if (attributes.hasOwnProperty(key)) {
-          element[options.attributesKey][key] = attributes[key];
+          if (options.simpleAttributes){
+            element[key] = attributes[key];
+          } else {
+            element[options.attributesKey][key] = attributes[key];
+          }
         }
       }
     }
@@ -239,7 +246,7 @@ function onStartElement(name, attributes) {
     element = {};
     element[options.typeKey] = 'element';
     element[options.nameKey] = name;
-    if (!options.ignoreAttributes && attributes && Object.keys(attributes).length) {
+    if (!options.ignoreAttributes && attributes && Object.keys(attributes).length && !options.simpleAttributes) {
       element[options.attributesKey] = attributes;
     }
     if (options.alwaysChildren) {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "coverage:codecov": "codecov --token=0e52af41-702b-4d7f-8aa3-61145ac36624 --file=test/coverage-jasmine/lcov.info ",
     "coverage:codacy": "cross-env CODACY_PROJECT_TOKEN=0207815122ea49a68241d1aa435f21f1 && cat ./test/coverage-jasmine/lcov.info | codacy-coverage",
     "coverage:codeclimate": "cross-env CODECLIMATE_REPO_TOKEN=60848a077f9070acf358b0c7145f0a2698a460ddeca7d8250815e75aa4333f7d codeclimate-test-reporter < test\\coverage-jasmine\\lcov.info",
-    "prepublish": "npm run test",
     "test": "npm run jasmine && npm run jest && npm run test:types",
     "test:types": "tsc -p ./types"
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -73,6 +73,7 @@ declare namespace Options {
       attributeValue: string,
       parentElement: string
     ) => void;
+    simpleAttributes?: boolean;
     attributeValueFn?: (
       attributeValue: string,
       attributeName: string,


### PR DESCRIPTION
where attributes are directly added as keys to the element object instead of being placed into a separate `_attributes` object

this makes it much easier to work with xml that don't have text inbetween the tags and instead keeps all its info in single `<element />`. 

It's really annoying to work with the _attributes object constantly if your XML shape is anything like the following: 

```xml
<parent attr1="one" attr2="two">
   <child k1="1" k2="2" ... kn="n" />
   <child k1="1" k2="2" ... kn="n" />
   ...
</parent>
```

before
```js
{
  parent: {
  __attributes: {attr1: "one", attr2: "two"},
  child: [{__attributes: {k1: "1", k2:"2", kn: "n"} }]
  }
 }
```

after
```js
{
  parent: {
  attr1: "one", 
  attr2: "two"
  child: [{k1: "1", k2:"2", kn: "n"}]
  }
 }
```